### PR TITLE
 Mixed-case directory names break 'podman create'

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -794,7 +794,7 @@ class PodmanCompose:
         os.chdir(dirname)
 
         if not project_name:
-            project_name = dir_basename
+            project_name = dir_basename.lower()
         self.project_name = project_name
         
 


### PR DESCRIPTION
The default project_name uses the directory name, but 'podman create' fails if the directory is mixed case.